### PR TITLE
Small fix to handling of comments within proofs (BofL)

### DIFF
--- a/coq2html.mll
+++ b/coq2html.mll
@@ -293,9 +293,10 @@ rule coq_bol = parse
         doc lexbuf;
         end_doc();
         skip_newline lexbuf }
-  | space* "(*"
-      { comment lexbuf;
-        skip_newline lexbuf }
+  | (space* as s) "(*"
+      { if !in_proof then (space s; start_comment());
+	comment lexbuf;
+        if !in_proof then coq lexbuf else skip_newline lexbuf }
   | eof
       { () }
   | space* as s


### PR DESCRIPTION
Fixes problems when handling `(*` when within a proof and at beginning of line.