### PR TITLE
Makefile: fix missing dependency coq2html.cmx: resources.cmx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ coq2html: resources.cmx coq2html.cmx
 %.ml: %.mll
 	$(OCAMLLEX) $*.mll
 
+coq2html.cmx: resources.cmx
+
 resources.ml: coq2html.css coq2html.js coq2html.header coq2html.footer coq2html.redirect
 	(for i in header footer css js redirect; do \
          echo "let $$i = {xxx|"; \


### PR DESCRIPTION
This could break parallel builds as witnessed at
https://github.com/coq-bench/make-html/blob/db76b0c3b16d15c66aed8efdc750c71fba9e36a6/black_list.rb#L13