### PR TITLE
Missing indent before Proof

### DIFF
--- a/coq2html.css
+++ b/coq2html.css
@@ -3,7 +3,7 @@
      div.coq      encloses all generated body
      div.doc      contents of (** *) comments
      div.footer   footer
-     div.togglescript   "Proof." line
+     span.togglescript   "Proof." line
      div.proofscript  contents of proof script
      span.docright contents of (**r *) comments
      span.bracket contents of [ ] within comments
@@ -51,12 +51,12 @@ div.doc {
   font-family: serif;
 }
 
-div.toggleproof {
+span.toggleproof {
   font-size: 0.8em;
   text-decoration: underline;
 }
 
-div.toggleproof:hover {
+span.toggleproof:hover {
   cursor: pointer;
 }
 

--- a/coq2html.mll
+++ b/coq2html.mll
@@ -261,12 +261,15 @@ let end_bracket () =
 let in_proof = ref false
 let proof_counter = ref 0
 
-let start_proof kwd =
+let start_proof s kwd =
   in_proof := true;
   incr proof_counter;
+  fprintf !oc "<div>";
+  space s;
   fprintf !oc
-  "<div class=\"toggleproof\" onclick=\"toggleDisplay('proof%d')\">%s</div>\n"
-    !proof_counter kwd;
+    "<span class=\"toggleproof\" onclick=\"toggleDisplay('proof%d')\">%s</span></div>\n"
+    !proof_counter
+    kwd;
   fprintf !oc "<div class=\"proofscript\" id=\"proof%d\">\n" !proof_counter
 
 let end_proof kwd =
@@ -296,8 +299,8 @@ let xref = ['A'-'Z' 'a'-'z' '0'-'9' '_' '.']+ | "<>"
 let integer = ['0'-'9']+
 
 rule coq_bol = parse
-  | space* (start_proof as sp)
-      { start_proof sp;
+  | (space* as s) (start_proof as sp)
+      { start_proof s sp;
         skip_newline lexbuf }
   | space* "(** " ("*"+ as sect)
       { start_section sect;


### PR DESCRIPTION
This is a detail, but with the current HTML generation, the first line of `Proof` located under `Module` or `Section` are not properly indented. For instance: 
```coq
Module MyMod.
  Lemma taut: forall A : Prop, A -> A.
  Proof.
    auto.
  Qed.
End MyMod.
```
Is exported as:
![2021-04-07-121042_304x95_scrot](https://user-images.githubusercontent.com/24356589/113850247-8d851900-979a-11eb-8b18-22a9e7693699.png)

Here is the result after my modifications:
![2021-04-07-124959_281x94_scrot](https://user-images.githubusercontent.com/24356589/113855049-de4b4080-979f-11eb-883c-1bf24afa29de.png)

The `Qed` line is still a bit skewed to the left (due to the proof script being in a smaller font), which is bothering me, but I'm not sure how to fix it...