### PR TITLE
bugfix: end of detail tag for proofs

### DIFF
--- a/coq2html.mll
+++ b/coq2html.mll
@@ -241,6 +241,7 @@ let end_string () =
 let in_proof = ref false
 
 let start_proof s kwd =
+  in_proof := true;
   fprintf !oc "<details>\n";
   space s;
   fprintf !oc "<summary class=\"toggleproof\">%s</summary>\n" kwd;


### PR DESCRIPTION
Fix a problem in which the closing tag of the detail for proof was not generated.